### PR TITLE
Update mailman2sympa.sh

### DIFF
--- a/mailman2sympa.sh
+++ b/mailman2sympa.sh
@@ -83,6 +83,11 @@ if [ $CONVERT_ARCHIVE = "yes" ] ; then
 	echo
 	echo Converting Archives
 	for l in `cat $WDIR/mailman-lists` ; do
+		host_name=$(jq -r .host_name < $WDIR/lists/$l)
+		if [ -n "$host_name" -a "$DOMAIN" != "$host_name" ]; then
+			echo "Skipping $l - domain doesn't match"
+			continue
+		fi
 		./scripts/getmailmanarchive $l
 	done
 	echo "To regenerate web archive as listmaster go to 'Sympa Admin' and under 'Archive' is options to regenerate html"


### PR DESCRIPTION
To avoid generating the archive if the domain is not the same as in the config, it avoids having false archive folders with list@domain1 then list@domain2 when list@domain1 does not exist. .. it's disk space on the disk for nothing ...
This in the case where the script is launched several times with several domains...